### PR TITLE
Fixed an issue with GetFiles

### DIFF
--- a/MobileDevice/iPhone.cs
+++ b/MobileDevice/iPhone.cs
@@ -353,7 +353,7 @@ namespace MobileDevice
 			MobileDevice.AFCDirectoryRead(hAFC, dir, ref buffer);
 			while (buffer != null)
 			{
-				if (!IsDirectory(path))
+                if (!IsDirectory(string.Format("{0}/{1}", path, buffer)))
 				{
 					list.Add(buffer);
 				}


### PR DESCRIPTION
Fixed an issue where GetFiles was always checking if the specific target
was a directory rather than the actual directory. This was causing an empty array to always be returned.
